### PR TITLE
Create build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,5 @@
+
+	libraryDependencies += "com.github.Dev-Re2906" % "BTC-ETFT" % "-SNAPSHOT
+ 
+	libraryDependencies += "com.github.Dev-Re2906" % "BTC-ETFT" % "Tag"	
+این نسخه را به اشتراک بگذارید:


### PR DESCRIPTION
approve

## خلاصه توسط Sourcery

ساخت:
- معرفی build.sbt برای تعریف libraryDependencies برای نسخه‌های SNAPSHOT و Tag از BTC-ETFT
```sbt
libraryDependencies ++= Seq(
  "org.scalatest" %% "scalatest" % "3.2.18" % Test,
  "com.thesamet.scaladocs" %% "scaladocs-macros" % "0.4.0" % Provided
)
```

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Introduce build.sbt to declare libraryDependencies for both SNAPSHOT and Tag versions of BTC-ETFT

</details>